### PR TITLE
docs(debugging): update post body json to remove capital `Job`

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -51,7 +51,7 @@ GCP: `POST https://<cloud-run-endpoint>/v1alpha/createJob`
         "output_domain_bucket_name": "<data_bucket>",
         "debug_run": "true"
     },
-    "Job_request_id": "test01"
+    "job_request_id": "test01"
 }
 ```
 


### PR DESCRIPTION
I noticed it says in [CONTRIBUTING.md](https://github.com/privacysandbox/aggregation-service/blob/main/CONTRIBUTING.md) that this project isn't accepting contributions, but hopefully a small documentation change is allowed. The capital J in job creates the following error in the frontend service (`/v1alpha1/createJob` endpoint) which is a bit unclear if you don't notice the extra capital:

```json
{
	"code": 6,
	"message": "Duplicate job_request_id provided: job_request_id= is not unique.",
	"details": [
		{
			"reason": "DUPLICATE_JOB_KEY",
			"domain": "",
			"metadata": {
			}
		}
	]
}
```

This PR addresses that small inconsistency to match the example provided here [GCP Aggregation Service - Testing The System](https://github.com/privacysandbox/aggregation-service/blob/main/docs/gcp-aggregation-service.md#testing-the-system)