### PR TITLE
Apply changes for b/348972742

### DIFF
--- a/docs/batching-strategies.md
+++ b/docs/batching-strategies.md
@@ -123,7 +123,7 @@ report accounting.
 
 Private Aggregation does not have an attribution_destination field, which is the advertiser. It is
 recommended to batch by advertiser, meaning to include reports belonging to a single advertiser in
-the same batch, to avoid hitting the aggregatable report account limit for each batch. Advertiser is
+the same batch, to avoid hitting the shared ID limit for each batch. Advertiser is
 a field considered in sharedID generation, so reports with the same advertiser could also have the
 same sharedID, which would require them to be in the same batch to avoid errors.
 


### PR DESCRIPTION
For bug 348972742 ("Incorrect reference to aggregate report account limit in batching strategy doc"), in second paragraph of "Batch by advertiser" section, changed  second sentence from "...hitting the aggregatable report report account limit for each batch" to read "...hitting the shared ID limit for each batch."