### PR TITLE
fix documentation to upgrade aggregation service on GCP

### DIFF
--- a/docs/gcp-aggregation-service.md
+++ b/docs/gcp-aggregation-service.md
@@ -330,7 +330,7 @@ file into smaller shards.
 
 Run the following in the `<repository_root>`.
 
-```
+```sh
 git fetch origin && git checkout -b dev-v{VERSION} v{VERSION}
 cd terraform/gcp
 bash download_prebuilt_dependencies.sh
@@ -339,7 +339,7 @@ bash download_prebuilt_dependencies.sh
 
 Execute the following commands with your own Google Cloud account. If you were previously impersonating a service account, clean the environment variable :
 
-```
+```sh
 export GOOGLE_IMPERSONATE_SERVICE_ACCOUNT=""
 cd environments/adtech_setup
 terraform plan
@@ -348,7 +348,7 @@ terraform apply
 
 Execute the following command by impersonating the Deploy Service Account :
 
-```
+```sh
 export GOOGLE_IMPERSONATE_SERVICE_ACCOUNT="<YourDeployServiceAccountName>@<ProjectID>.iam.gserviceaccount.com"
 cd ../dev
 terraform apply

--- a/docs/gcp-aggregation-service.md
+++ b/docs/gcp-aggregation-service.md
@@ -331,7 +331,7 @@ file into smaller shards.
 Run the following in the `<repository_root>`.
 
 ```
-git pull
+git fetch origin && git checkout -b dev-v{VERSION} v{VERSION}
 cd terraform/gcp
 bash download_prebuilt_dependencies.sh
 
@@ -349,7 +349,7 @@ terraform apply
 Execute the following command by impersonating the Deploy Service Account :
 
 ```
-export GOOGLE_IMPERSONATE_SERVICE_ACCOUNT="deploy-sa@gtech-privacy-aggregation-dev.iam.gserviceaccount.com"
+export GOOGLE_IMPERSONATE_SERVICE_ACCOUNT="<YourDeployServiceAccountName>@<ProjectID>.iam.gserviceaccount.com"
 cd ../dev
 terraform apply
 ```

--- a/docs/gcp-aggregation-service.md
+++ b/docs/gcp-aggregation-service.md
@@ -326,17 +326,34 @@ file into smaller shards.
     [Google Cloud Function instructions](https://cloud.google.com/functions/docs/securing/authenticating)
     for sending an authenticated request. [Detailed API spec](/docs/api.md#getjob-endpoint)_
 
-## Updating the system
+# **Upgrade Environment**
 
 Run the following in the `<repository_root>`.
 
-```sh
-git fetch origin && git checkout -b dev-v{VERSION} v{VERSION}
+```
+git pull
 cd terraform/gcp
 bash download_prebuilt_dependencies.sh
-cd environments/dev
+
+```
+
+Execute the following commands with your own Google Cloud account. If you were previously impersonating a service account, clean the environment variable :
+
+```
+export GOOGLE_IMPERSONATE_SERVICE_ACCOUNT=""
+cd environments/adtech_setup
+terraform plan
 terraform apply
 ```
+
+Execute the following command by impersonating the Deploy Service Account :
+
+```
+export GOOGLE_IMPERSONATE_SERVICE_ACCOUNT="deploy-sa@gtech-privacy-aggregation-dev.iam.gserviceaccount.com"
+cd ../dev
+terraform apply
+```
+
 
 _Note: If you use self-built artifacts described in
 [build-scripts/gcp](/build-scripts/gcp/README.md), run `bash fetch_terraform.sh` instead of


### PR DESCRIPTION
added  instruction to upgrade re-apply `adtech_setup` terraform as well (since the permission assigned to the Service Account may need to be updated in the future)